### PR TITLE
Reset default language from Japanese to English

### DIFF
--- a/learnyoureact.js
+++ b/learnyoureact.js
@@ -14,6 +14,6 @@ workshopper({
     appDir      : __dirname,
     menuItems   : [],
     languages   : ['en', 'ja', 'ko'],
-    defaultLang : 'ja',
+    defaultLang : 'en',
     exerciseDir : fpath('./exercises/')
 })


### PR DESCRIPTION
When I npm installed this project on my machine, the terminal shows Japanese by default.
It could be better if we can set English as default language so that won't cause confusion for users who doesn't have Japanese language installed on their machine.

see screenshot.
![capture](https://cloud.githubusercontent.com/assets/4587603/8948292/0033b944-35e9-11e5-957a-2ff348eae290.GIF)
