### PR TITLE
Missing modules

### DIFF
--- a/exercises/hello_react/problem.en.md
+++ b/exercises/hello_react/problem.en.md
@@ -7,7 +7,7 @@ You can change `learnyoureact` to any name you like.
 
 Start by installing the required modules. Run this command:
 
-    $ npm install  react react-dom express body-parser express-react-views node-jsx
+    $ npm install react react-dom express body-parser express-react-views node-jsx
 
 You can see `node_modules` directory maked.
 Files of module is in the directory.

--- a/exercises/hello_react/problem.en.md
+++ b/exercises/hello_react/problem.en.md
@@ -7,7 +7,7 @@ You can change `learnyoureact` to any name you like.
 
 Start by installing the required modules. Run this command:
 
-    $ npm install express body-parser express-react-views node-jsx
+    $ npm install  react react-dom express body-parser express-react-views node-jsx
 
 You can see `node_modules` directory maked.
 Files of module is in the directory.


### PR DESCRIPTION
The first exercise requires the `react` and `react-dom` modules but does not include them in the list to be installed.

It's possible that an older version of NPM installed them automatically via peer dependencies or something else, but with NPM 3 they were missing.
