### PR TITLE
relates to #43: convert from node-jsx to babel

### DIFF
--- a/exercises/components/solution/solution.js
+++ b/exercises/components/solution/solution.js
@@ -6,7 +6,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
 	res.render('index', '');

--- a/exercises/css/solution/solution.js
+++ b/exercises/css/solution/solution.js
@@ -6,7 +6,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
 	res.render('index', '');

--- a/exercises/css2/solution/solution.js
+++ b/exercises/css2/solution/solution.js
@@ -15,7 +15,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 var TodoBox = require('./views/index.jsx');
 
 var data = [

--- a/exercises/event/solution/solution.js
+++ b/exercises/event/solution/solution.js
@@ -15,7 +15,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 var TodoBox = require('./views/index.jsx');
 
 var data = [

--- a/exercises/hello_react/problem.en.md
+++ b/exercises/hello_react/problem.en.md
@@ -7,7 +7,7 @@ You can change `learnyoureact` to any name you like.
 
 Start by installing the required modules. Run this command:
 
-    $ npm install react react-dom express body-parser express-react-views node-jsx
+    $ npm install react react-dom express body-parser express-react-views
 
 You can see `node_modules` directory maked.
 Files of module is in the directory.
@@ -32,7 +32,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
   res.render('index', '');

--- a/exercises/hello_react/problem.ko.md
+++ b/exercises/hello_react/problem.ko.md
@@ -10,7 +10,7 @@ $ mkdir learnyoureact
 
 필요한 모듈을 설치하려면 밑의 명령을 실행해 보세요.
 
-    $ npm install react react-dom express body-parser express-react-views node-jsx
+    $ npm install react react-dom express body-parser express-react-views
 
 이제 `node_modules` 디렉터리가 만들어진 것을 볼 수 있습니다.
 
@@ -33,7 +33,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
   res.render('index', '');

--- a/exercises/hello_react/problem.md
+++ b/exercises/hello_react/problem.md
@@ -8,7 +8,7 @@
 それができたら、そのフォルダの中にモジュールをインストールしましょう。
 以下のコマンドを実行してください。
 
-`$ npm install react react-dom express body-parser express-react-views node-jsx`
+`$ npm install react react-dom express body-parser express-react-views`
 
 `node_modules` というフォルダが作成されたかと思います。その中にモジュールのフォルダがあります。
 
@@ -32,7 +32,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
   res.render('index', '');

--- a/exercises/hello_react/solution/solution.js
+++ b/exercises/hello_react/solution/solution.js
@@ -6,7 +6,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
 	res.render('index', '');

--- a/exercises/isomorphic/problem.en.md
+++ b/exercises/isomorphic/problem.en.md
@@ -48,10 +48,10 @@ var script = DOM.script;
 var browserify = require('browserify');
 ```
 
-Next, add a line that reads `index.jsx` under the sentence that `require` s `node-jsx`.
+Next, add a line that reads `index.jsx` under the sentence that `require` s `babel/register`.
 
 ```
-require('node-jsx').install();
+require('babel/register');
 var TodoBox = require('./views/index.jsx');
 ```
 

--- a/exercises/isomorphic/problem.ko.md
+++ b/exercises/isomorphic/problem.ko.md
@@ -45,10 +45,10 @@ var script = DOM.script;
 var browserify = require('browserify');
 ```
 
-그런 다음 `node-jsx`를 `require`하고 있는 구문 밑에 다음과 같이 `index.jsx`를 불러 오도록 추가해 주세요.
+그런 다음 `babel/register`를 `require`하고 있는 구문 밑에 다음과 같이 `index.jsx`를 불러 오도록 추가해 주세요.
 
 ```
-require('node-jsx').install();
+require('babel/register');
 var TodoBox = require('./views/index.jsx');
 ```
 

--- a/exercises/isomorphic/problem.md
+++ b/exercises/isomorphic/problem.md
@@ -44,10 +44,10 @@ var script = DOM.script;
 var browserify = require('browserify');
 ```
 
-次に `node-jsx` を `require` している文の下に以下のように `index.jsx` を読み込む処理を1行追加してください。
+次に `babel/register` を `require` している文の下に以下のように `index.jsx` を読み込む処理を1行追加してください。
 
 ```
-require('node-jsx').install();
+require('babel/register');
 var TodoBox = require('./views/index.jsx');
 ```
 

--- a/exercises/isomorphic/solution/solution.js
+++ b/exercises/isomorphic/solution/solution.js
@@ -15,7 +15,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 var TodoBox = require('./views/index.jsx');
 
 var data = [

--- a/exercises/prop_and_state/solution/solution.js
+++ b/exercises/prop_and_state/solution/solution.js
@@ -15,7 +15,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 var TodoBox = require('./views/index.jsx');
 
 var data = [

--- a/exercises/props/solution/solution.js
+++ b/exercises/props/solution/solution.js
@@ -3,10 +3,10 @@ var app = express();
 
 app.set('port', (process.argv[2] || 3000));
 app.set('view engine', 'jsx');
-app.set('views', __dirname + '/views'); 
+app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
 	res.render('index', '');

--- a/exercises/props_from_server/problem.en.md
+++ b/exercises/props_from_server/problem.en.md
@@ -6,7 +6,7 @@ This will require changing code on the server (`program.js`).
 # Challenge
 ---
 
-Modify `TodoBox` and `TodoList` in `index.jsx` like below. 
+Modify `TodoBox` and `TodoList` in `index.jsx` like below.
 
 Before you start, you may want to check your current `index.jsx` into source
 control, or create a new `index.jsx` for this exercise.
@@ -79,10 +79,10 @@ var app = express();
 
 app.set('port', (process.argv[2] || 3000));
 app.set('view engine', 'jsx');
-app.set('views', __dirname + '/views'); 
+app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 // write below
 var data = [];

--- a/exercises/props_from_server/problem.ko.md
+++ b/exercises/props_from_server/problem.ko.md
@@ -74,10 +74,10 @@ var app = express();
 
 app.set('port', (process.argv[2] || 3000));
 app.set('view engine', 'jsx');
-app.set('views', __dirname + '/views'); 
+app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 // 여기에 추가
 var data = [];

--- a/exercises/props_from_server/problem.md
+++ b/exercises/props_from_server/problem.md
@@ -72,10 +72,10 @@ var app = express();
 
 app.set('port', (process.argv[2] || 3000));
 app.set('view engine', 'jsx');
-app.set('views', __dirname + '/views'); 
+app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 // ↓に記述
 var data = [];

--- a/exercises/props_from_server/solution/solution.js
+++ b/exercises/props_from_server/solution/solution.js
@@ -3,10 +3,10 @@ var app = express();
 
 app.set('port', (process.argv[2] || 3000));
 app.set('view engine', 'jsx');
-app.set('views', __dirname + '/views'); 
+app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 var data = [
 	{ title: 'Shopping', detail: process.argv[3] },

--- a/exercises/proptypes/solution/solution.js
+++ b/exercises/proptypes/solution/solution.js
@@ -3,10 +3,10 @@ var app = express();
 
 app.set('port', (process.argv[2] || 3000));
 app.set('view engine', 'jsx');
-app.set('views', __dirname + '/views'); 
+app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
 	res.render('index', '');

--- a/exercises/state/solution/solution.js
+++ b/exercises/state/solution/solution.js
@@ -3,10 +3,10 @@ var app = express();
 
 app.set('port', (process.argv[2] || 3000));
 app.set('view engine', 'jsx');
-app.set('views', __dirname + '/views'); 
+app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine());
 
-require('node-jsx').install();
+require('babel/register');
 
 app.use('/', function(req, res) {
 	res.render('index', '');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "express-react-views": "~0.9.0",
     "hyperquest": "~1.2.0",
     "js-beautify": "^1.5.10",
-    "node-jsx": "~0.13.3",
     "react": "~0.14.0",
     "reactify": "~1.1.1",
     "react-dom": "~0.14.0",


### PR DESCRIPTION
Converts all references from `node-jsx` to `babel/register`. Hopefully the changes I made to the Korean and Japanese language files are correct -- I replaced the text but can't read or write the languages.

this does not completely resolve #43, but does get rid of the deprecated `node-jsx` dependency.
