### PR TITLE
Ignore Babel 100kb notes

### DIFF
--- a/exercises/css2/solution/solution.js
+++ b/exercises/css2/solution/solution.js
@@ -32,7 +32,8 @@ app.use('/bundle.js', function (req, res) {
 
     browserify({debug: true})
         .transform(babelify.configure({
-            presets: ["react", "es2015"]
+            presets: ["react", "es2015"],
+            compact: false
         }))
         .require("css2/solution/app.js", {entry: true})
         .bundle()

--- a/exercises/event/solution/solution.js
+++ b/exercises/event/solution/solution.js
@@ -32,7 +32,8 @@ app.use('/bundle.js', function (req, res) {
 
     browserify({debug: true})
         .transform(babelify.configure({
-            presets: ["react", "es2015"]
+            presets: ["react", "es2015"],
+            compact: false
         }))
         .require("event/solution/app.js", {entry: true})
         .bundle()

--- a/exercises/isomorphic/problem.en.md
+++ b/exercises/isomorphic/problem.en.md
@@ -69,7 +69,8 @@ app.use('/bundle.js', function (req, res) {
 
     browserify({ debug: true })
         .transform(babelify.configure({
-            presets: ["react", "es2015"]
+            presets: ["react", "es2015"],
+            compact: false
         }))
         .require("./app.js", { entry: true })
         .bundle()

--- a/exercises/isomorphic/problem.ko.md
+++ b/exercises/isomorphic/problem.ko.md
@@ -67,7 +67,8 @@ app.use('/bundle.js', function (req, res) {
 
     browserify({ debug: true })
         .transform(babelify.configure({
-            presets: ["react", "es2015"]
+            presets: ["react", "es2015"],
+            compact: false
         }))
         .require("./app.js", { entry: true })
         .bundle()

--- a/exercises/isomorphic/problem.md
+++ b/exercises/isomorphic/problem.md
@@ -67,7 +67,8 @@ app.use('/bundle.js', function (req, res) {
 
     browserify({ debug: true })
         .transform(babelify.configure({
-            presets: ["react", "es2015"]
+            presets: ["react", "es2015"],
+            compact: false
         }))
         .require("./app.js", { entry: true })
         .bundle()

--- a/exercises/isomorphic/solution/solution.js
+++ b/exercises/isomorphic/solution/solution.js
@@ -32,7 +32,8 @@ app.use('/bundle.js', function (req, res) {
 
     browserify({debug: true})
         .transform(babelify.configure({
-            presets: ["react", "es2015"]
+            presets: ["react", "es2015"],
+            compact: false
         }))
         .require("isomorphic/solution/app.js", {entry: true})
         .bundle()

--- a/exercises/prop_and_state/solution/solution.js
+++ b/exercises/prop_and_state/solution/solution.js
@@ -32,7 +32,8 @@ app.use('/bundle.js', function (req, res) {
 
     browserify({debug: true})
         .transform(babelify.configure({
-            presets: ["react", "es2015"]
+            presets: ["react", "es2015"],
+            compact: false
         }))
         .require("prop_and_state/solution/app.js", {entry: true})
         .bundle()


### PR DESCRIPTION
refs #93 
`[BABEL] Note: The code generator has deoptimised the styling of "~" as it exceeds the max of "100KB".` is not an error and is a note.
And it's not essential for beginner.
So, I change to ignore the note.
