### PR TITLE
Fix to avoid server crash in exercise 8 isomorphic (#111)

### DIFF
--- a/exercises/isomorphic/problem.en.md
+++ b/exercises/isomorphic/problem.en.md
@@ -52,9 +52,7 @@ var babelify = require("babelify");
 Next, add a line that reads `index.jsx` under the sentence that `require` s `babel/register`.
 
 ```
-require('babel/register')({
-    ignore: false
-});
+require('babel/register');
 
 var TodoBox = require('./views/index.jsx');
 ```
@@ -67,12 +65,8 @@ If you have an access to `/`, you response HTML that consists of reading `index.
 app.use('/bundle.js', function (req, res) {
     res.setHeader('content-type', 'application/javascript');
 
-    browserify({ debug: true })
-        .transform(babelify.configure({
-            presets: ["react", "es2015"],
-            compact: false
-        }))
-        .require("./app.js", { entry: true })
+    browserify("./app.js")
+        .transform("babelify", {presets: ["es2015", "react"]})
         .bundle()
         .pipe(res);
 });

--- a/exercises/isomorphic/problem.ko.md
+++ b/exercises/isomorphic/problem.ko.md
@@ -49,9 +49,7 @@ var babelify = require("babelify");
 그런 다음 `babel/register`를 `require`하고 있는 구문 밑에 다음과 같이 `index.jsx`를 불러 오도록 추가해 주세요.
 
 ```
-require('babel/register')({
-    ignore: false
-});
+require('babel/register');
 
 var TodoBox = require('./views/index.jsx');
 ```
@@ -65,12 +63,8 @@ var TodoBox = require('./views/index.jsx');
 app.use('/bundle.js', function (req, res) {
     res.setHeader('content-type', 'application/javascript');
 
-    browserify({ debug: true })
-        .transform(babelify.configure({
-            presets: ["react", "es2015"],
-            compact: false
-        }))
-        .require("./app.js", { entry: true })
+    browserify("./app.js")
+        .transform("babelify", {presets: ["es2015", "react"]})
         .bundle()
         .pipe(res);
 });

--- a/exercises/isomorphic/problem.md
+++ b/exercises/isomorphic/problem.md
@@ -49,9 +49,7 @@ var babelify = require("babelify");
 次に `babel/register` を `require` している文の下に以下のように `index.jsx` を読み込む処理を1行追加してください。
 
 ```
-require('babel/register')({
-    ignore: false
-});
+require('babel/register');
 
 var TodoBox = require('./views/index.jsx');
 ```
@@ -65,12 +63,8 @@ var TodoBox = require('./views/index.jsx');
 app.use('/bundle.js', function (req, res) {
     res.setHeader('content-type', 'application/javascript');
 
-    browserify({ debug: true })
-        .transform(babelify.configure({
-            presets: ["react", "es2015"],
-            compact: false
-        }))
-        .require("./app.js", { entry: true })
+    browserify("./app.js")
+        .transform("babelify", {presets: ["es2015", "react"]})
         .bundle()
         .pipe(res);
 });

--- a/exercises/isomorphic/solution/solution.js
+++ b/exercises/isomorphic/solution/solution.js
@@ -16,9 +16,7 @@ app.set('view engine', 'jsx');
 app.set('views', __dirname + '/views');
 app.engine('jsx', require('express-react-views').createEngine({transformViews: false}));
 
-require('babel/register')({
-    ignore: false
-});
+require('babel/register');
 
 var TodoBox = require('./views/index.jsx');
 
@@ -30,12 +28,8 @@ var data = [
 app.use('/bundle.js', function (req, res) {
     res.setHeader('content-type', 'application/javascript');
 
-    browserify({debug: true})
-        .transform(babelify.configure({
-            presets: ["react", "es2015"],
-            compact: false
-        }))
-        .require("isomorphic/solution/app.js", {entry: true})
+    browserify("./app.js")
+        .transform("babelify", {presets: ["es2015", "react"]})
         .bundle()
         .pipe(res);
 });


### PR DESCRIPTION
Recently, the exercise 8 "isomorphic" causes server crash when getting `/bundle.js` (#111),
that blocks all the rest exercises for the front-end react.

I found a way to avoid the crash finally, so hope this will be of some help.