### PR TITLE
Fix for regexp replacements used by verify steps

### DIFF
--- a/exercises/css2/exercise.js
+++ b/exercises/css2/exercise.js
@@ -95,13 +95,10 @@ function query(mode) {
             if (err) {
                 exercise.emit('fail', exercise.__('fail.connection', {address: url, message: err.message}));
             } else {
-                var data = _data.toString().replace(/data-react-checksum=".{1,20}"/, "");
-                while (data.match(/data-reactid=".{1,20}"/)) {
-                    data = data.replace(/data-reactid=".{1,20}"/, "");
-                }
-                while (data.match(/data-reactid=".{1,35}"/)) {
-                    data = data.replace(/data-reactid=".{1,35}"/, "");
-                }
+                var data = _data.toString().replace(/data-react-checksum="[^"]{1,20}"/, "");
+                data = data.replace(/data-reactroot=""/, "");
+                data = data.replace(/data-reactid="[^"]{1,35}"/gm, "");
+                data = data.replace(/data-reactid="[^"]{1,35}"/gm, "");
                 data = beautify_html(data, null);
                 stream.write(data);
             }

--- a/exercises/event/exercise.js
+++ b/exercises/event/exercise.js
@@ -95,13 +95,9 @@ function query(mode) {
             if (err) {
                 exercise.emit('fail', exercise.__('fail.connection', {address: url, message: err.message}));
             } else {
-                var data = _data.toString().replace(/data-react-checksum=".{1,20}"/, "");
-                while (data.match(/data-reactid=".{1,20}"/)) {
-                    data = data.replace(/data-reactid=".{1,20}"/, "");
-                }
-                while (data.match(/data-reactid=".{1,35}"/)) {
-                    data = data.replace(/data-reactid=".{1,35}"/, "");
-                }
+                var data = _data.toString().replace(/data-react-checksum="[^"]{1,20}"/, "");
+                data = data.replace(/data-reactroot=""/, "");
+                data = data.replace(/data-reactid="[^"]{1,35}"/gm, "");
                 data = beautify_html(data, null);
                 stream.write(data);
             }

--- a/exercises/isomorphic/exercise.js
+++ b/exercises/isomorphic/exercise.js
@@ -95,13 +95,10 @@ function query(mode) {
             if (err) {
                 exercise.emit('fail', exercise.__('fail.connection', {address: url, message: err.message}));
             } else {
-                var data = _data.toString().replace(/data-react-checksum=".{1,20}"/, "");
-                while (data.match(/data-reactid=".{1,20}"/)) {
-                    data = data.replace(/data-reactid=".{1,20}"/, "");
-                }
-                while (data.match(/data-reactid=".{1,35}"/)) {
-                    data = data.replace(/data-reactid=".{1,35}"/, "");
-                }
+                var data = _data.toString().replace(/data-react-checksum="[^"]{1,20}"/, "");
+                data = data.replace(/data-reactroot=""/, "");
+                data = data.replace(/data-reactid="[^"]{1,35}"/g, "");
+                data = data.replace(/data-reactid="[^"]{1,35}"/g, "");
                 data = beautify_html(data, null);
                 stream.write(data);
             }

--- a/exercises/prop_and_state/exercise.js
+++ b/exercises/prop_and_state/exercise.js
@@ -96,13 +96,10 @@ function query(mode) {
                 exercise.emit('fail', exercise.__('fail.connection', {address: url, message: err.message}));
                 return;
             } else {
-                var data = _data.toString().replace(/data-react-checksum=".{1,20}"/, "");
-                while (data.match(/data-reactid=".{1,20}"/)) {
-                    data = data.replace(/data-reactid=".{1,20}"/, "");
-                }
-                while (data.match(/data-reactid=".{1,35}"/)) {
-                    data = data.replace(/data-reactid=".{1,35}"/, "");
-                }
+                var data = _data.toString().replace(/data-react-checksum="[^"]{1,20}"/, "");
+                data = data.replace(/data-reactroot=""/, "");
+                data = data.replace(/data-reactid="[^"]{1,35}"/gm, "");
+                data = data.replace(/data-reactid="[^"]{1,35}"/gm, "");
                 data = beautify_html(data, null);
                 stream.write(data);
             }


### PR DESCRIPTION
While working on this workshopper, I ran into some problems verifying my solutions.
The generated HTML was being mangled by the regexp replacements, probably due to newline differences. The output was rather confusing and it took me a while to figure out. Hopefully this can prevent that experience for others. I think it's the same problem described in #103.

I've been using a newer version of React for the workshopper, which is likely why I ran into this problem. 
With the changes in this pull request, the workshopper should continue to work with React 0.14 as well as newer versions. Additional changes are necessary to bring the exercises and solutions up to date with React 15.5, but this should help along the way.